### PR TITLE
1.0.4

### DIFF
--- a/Oxide.Ext.Discord/DiscordClient.cs
+++ b/Oxide.Ext.Discord/DiscordClient.cs
@@ -29,6 +29,22 @@ namespace Oxide.Ext.Discord
 
         public List<Guild> DiscordServers { get; set; } = new List<Guild>();
 
+        // TEMP for the pre-release testing
+        public static bool DepricatedWarning = false;
+        public Guild DiscordServer
+        {
+            get
+            {
+                if (!DiscordClient.DepricatedWarning)
+                {
+                    Interface.Oxide.LogWarning("[Discord Extension] DiscordClient.DiscordServer is depcreated! Use DiscordClient.DiscordServers list instead!");
+                    DiscordClient.DepricatedWarning = true;
+                }
+                return this.DiscordServers?.FirstOrDefault();
+            }
+        }
+        //-----------
+
         public int Sequence;
 
         public string SessionID;

--- a/Oxide.Ext.Discord/DiscordClient.cs
+++ b/Oxide.Ext.Discord/DiscordClient.cs
@@ -27,7 +27,7 @@ namespace Oxide.Ext.Discord
 
         public DiscordSettings Settings { get; set; } = new DiscordSettings();
 
-        public Guild DiscordServer { get; set; }
+        public List<Guild> DiscordServers { get; set; } = new List<Guild>();
 
         public int Sequence;
 
@@ -304,11 +304,11 @@ namespace Oxide.Ext.Discord
             }
         }
         
-        public void RequestGuildMembers(string query = "", int limit = 0)
+        public void RequestGuildMembers(string guild_id, string query = "", int limit = 0)
         {
             var requestGuildMembers = new GuildMembersRequest()
             {
-                GuildID = DiscordServer.id,
+                GuildID = guild_id,
                 Query = query,
                 Limit = limit
             };
@@ -323,12 +323,17 @@ namespace Oxide.Ext.Discord
             _webSocket.Send(payload);
         }
 
-        public void UpdateVoiceState(string channelId, bool selfDeaf, bool selfMute)
+        public void RequestGuildMembers(Guild guild, string query = "", int limit = 0)
+        {
+            RequestGuildMembers(guild.id, query, limit);
+        }
+
+        public void UpdateVoiceState(string guildID, string channelId, bool selfDeaf, bool selfMute)
         {
             var voiceState = new VoiceStateUpdate()
             {
                 ChannelID = channelId,
-                GuildID = DiscordServer.id,
+                GuildID = guildID,
                 SelfDeaf = selfDeaf,
                 SelfMute = selfMute
             };
@@ -353,6 +358,20 @@ namespace Oxide.Ext.Discord
 
             var payload = JsonConvert.SerializeObject(opcode);
             _webSocket.Send(payload);
+        }
+
+        public Guild GetGuild(string id)
+        {
+            return this.DiscordServers?.FirstOrDefault(x => x.id == id);
+        }
+
+        public void UpdateGuild(string g_id, Guild newguild)
+        {
+            Guild g = this.GetGuild(g_id);
+            if (g == null) return;
+            int idx = DiscordServers?.IndexOf(g) ?? -1;
+            if (idx == -1) return;
+            this.DiscordServers[idx] = newguild;
         }
 
         #endregion

--- a/Oxide.Ext.Discord/DiscordClient.cs
+++ b/Oxide.Ext.Discord/DiscordClient.cs
@@ -41,6 +41,8 @@ namespace Oxide.Ext.Discord
 
         public bool HeartbeatACK = false;
 
+        public bool requestReconnect = false;
+
         public void Initialize(Plugin plugin, DiscordSettings settings)
         {
             if (plugin == null)
@@ -278,8 +280,8 @@ namespace Oxide.Ext.Discord
             {
                 // Didn't receive an ACK, thus connection can be considered zombie, thus destructing.
                 Interface.Oxide.LogError("[Discord Extension] Discord did not respond to Heartbeat! Disconnecting..");
+                requestReconnect = true;
                 _webSocket.Disconnect(false);
-                _webSocket.Connect(WSSURL);
                 return;
             }
             var packet = new RPayload()

--- a/Oxide.Ext.Discord/DiscordExtension.cs
+++ b/Oxide.Ext.Discord/DiscordExtension.cs
@@ -18,7 +18,7 @@
 
         public override string Author => "PsychoTea & DylanSMR & Tricky";
 
-        public override VersionNumber Version => new VersionNumber(1, 0, 3);
+        public override VersionNumber Version => new VersionNumber(1, 0, 4);
 
         public override void OnModLoad()
         {

--- a/Oxide.Ext.Discord/DiscordObjects/Channel.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Channel.cs
@@ -22,6 +22,8 @@
 
         public bool? nsfw { get; set; }
 
+        public string last_message_id { get; set; }
+
         public int? bitrate { get; set; }
 
         public int? user_limit { get; set; }
@@ -31,6 +33,15 @@
         public List<User> recipients { get; set; }
 
         public string icon { get; set; }
+
+        public string owner_id { get; set; }
+
+        public string application_id { get; set; }
+
+        public string parent_id { get; set; }
+
+        // TODO: Parse to DateTime
+        public string last_pin_timestamp { get; set; } 
 
         public static void GetChannel(DiscordClient client, string channelID, Action<Channel> callback = null)
         {

--- a/Oxide.Ext.Discord/DiscordObjects/Guild.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Guild.cs
@@ -366,5 +366,79 @@
         {
             client.REST.DoRequest($"/guilds/{id}/vanity-url", RequestMethod.GET, null, callback);
         }
+
+        public void Update(Guild UpdatedGuild)
+        {
+            if (UpdatedGuild.name != null)
+                this.name = UpdatedGuild.name;
+            if (UpdatedGuild.icon != null)
+                this.icon = UpdatedGuild.icon;
+            if (UpdatedGuild.splash != null)
+                this.splash = UpdatedGuild.splash;
+            if (UpdatedGuild.owner_id != null)
+                this.owner_id = UpdatedGuild.owner_id;
+            if (UpdatedGuild.region != null)
+                this.region = UpdatedGuild.region;
+            if (UpdatedGuild.afk_channel_id != null)
+                this.afk_channel_id = UpdatedGuild.afk_channel_id;
+            if (UpdatedGuild.afk_timeout != null)
+                this.afk_timeout = UpdatedGuild.afk_timeout;
+            if (UpdatedGuild.embed_enabled != null)
+                this.embed_enabled = UpdatedGuild.embed_enabled;
+            if (UpdatedGuild.embed_channel_id != null)
+                this.embed_channel_id = UpdatedGuild.embed_channel_id;
+            if (UpdatedGuild.verification_level != null)
+                this.verification_level = UpdatedGuild.verification_level;
+            if (UpdatedGuild.default_message_notifications != null)
+                this.default_message_notifications = UpdatedGuild.default_message_notifications;
+            if (UpdatedGuild.explicit_content_filter != null)
+                this.explicit_content_filter = UpdatedGuild.explicit_content_filter;
+            if (UpdatedGuild.roles != null)
+                this.roles = UpdatedGuild.roles;
+            if (UpdatedGuild.emojis != null)
+                this.emojis = UpdatedGuild.emojis;
+            if (UpdatedGuild.features != null)
+                this.features = UpdatedGuild.features;
+            if (UpdatedGuild.mfa_level != null)
+                this.mfa_level = UpdatedGuild.mfa_level;
+            if (UpdatedGuild.application_id != null)
+                this.application_id = UpdatedGuild.application_id;
+            if (UpdatedGuild.widget_enabled != null)
+                this.widget_enabled = UpdatedGuild.widget_enabled;
+            if (UpdatedGuild.widget_channel_id != null)
+                this.widget_channel_id = UpdatedGuild.widget_channel_id;
+            if (UpdatedGuild.system_channel_id != null)
+                this.system_channel_id = UpdatedGuild.system_channel_id;
+            if (UpdatedGuild.joined_at != null)
+                this.joined_at = UpdatedGuild.joined_at;
+            if (UpdatedGuild.large != null)
+                this.large = UpdatedGuild.large;
+            if (UpdatedGuild.unavailable != null)
+                this.unavailable = UpdatedGuild.unavailable;
+            if (UpdatedGuild.member_count != null)
+                this.member_count = UpdatedGuild.member_count;
+            if (UpdatedGuild.voice_states != null)
+                this.voice_states = UpdatedGuild.voice_states;
+            if (UpdatedGuild.members != null)
+                this.members = UpdatedGuild.members;
+            if (UpdatedGuild.channels != null)
+                this.channels = UpdatedGuild.channels;
+            if (UpdatedGuild.presences != null)
+                this.presences = UpdatedGuild.presences;
+            if (UpdatedGuild.max_presences != null)
+                this.max_presences = UpdatedGuild.max_presences;
+            if (UpdatedGuild.max_members != null)
+                this.max_members = UpdatedGuild.max_members;
+            if (UpdatedGuild.vanity_url_code != null)
+                this.vanity_url_code = UpdatedGuild.vanity_url_code;
+            if (UpdatedGuild.description != null)
+                this.description = UpdatedGuild.description;
+            if (UpdatedGuild.banner != null)
+                this.banner = UpdatedGuild.banner;
+            if (UpdatedGuild.premium_tier != null)
+                this.premium_tier = UpdatedGuild.premium_tier;
+            if (UpdatedGuild.premium_subscription_count != null)
+                this.premium_subscription_count = UpdatedGuild.premium_subscription_count;
+        }
     }
 }

--- a/Oxide.Ext.Discord/DiscordObjects/Presence.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Presence.cs
@@ -5,13 +5,13 @@
     public class Presence
     {
         [JsonProperty("status")]
-        public string Status { get; set; }
+        public string Status { get; set; } = "online";
 
         [JsonProperty("game")]
         public Game Game { get; set; }
 
         [JsonProperty("since")]
-        public int Since { get; set; }
+        public int? Since { get; set; }
 
         [JsonProperty("afk")]
         public bool AFK { get; set; }

--- a/Oxide.Ext.Discord/DiscordObjects/User.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/User.cs
@@ -114,5 +114,27 @@
         {
             client.REST.DoRequest($"/channels/{channelID}/recipients/{id}", RequestMethod.DELETE, null, callback);
         }
+
+        public void Update(User updateduser)
+        {
+            if (updateduser.avatar != null)
+                this.avatar = updateduser.avatar;
+            if (updateduser.bot != null)
+                this.bot = updateduser.bot;
+            if (updateduser.discriminator != null)
+                this.discriminator = updateduser.discriminator;
+            if (updateduser.email != null)
+                this.email = updateduser.email;
+            if (updateduser.locale != null)
+                this.locale = updateduser.locale;
+            if (updateduser.mfa_enabled != null)
+                this.mfa_enabled = updateduser.mfa_enabled;
+            if (updateduser.premium_type != null)
+                this.premium_type = updateduser.premium_type;
+            if (updateduser.username != null)
+                this.username = updateduser.username;
+            if (updateduser.verified != null)
+                this.verified = updateduser.verified;
+        }
     }
 }

--- a/Oxide.Ext.Discord/Helpers/CreationTime.cs
+++ b/Oxide.Ext.Discord/Helpers/CreationTime.cs
@@ -5,15 +5,17 @@
 
     public class CreationTime
     {
-        public static DateTime GetFromUser(User user) => GetFromUserID(user.id);
+        public static DateTime? GetFromUser(User user) => GetFromID(user.id);
 
-        public static DateTime GetFromUserID(string userID)
+        public static DateTime? GetFromID(string ID)
         {
-            long id = long.Parse(userID);
+            long id = 0;
+            long.TryParse(ID, out id);
+            if (id == 0) return null;
 
             long ageInSeconds = ((id >> 22) + 1420070400000) / 1000;
 
-            return new DateTime(1970, 1, 1).AddSeconds(ageInSeconds);
+            return new DateTime(2015, 1, 1).AddSeconds(ageInSeconds);
         }
     }
 }

--- a/Oxide.Ext.Discord/Helpers/CreationTime.cs
+++ b/Oxide.Ext.Discord/Helpers/CreationTime.cs
@@ -13,7 +13,7 @@
             long.TryParse(ID, out id);
             if (id == 0) return null;
 
-            long ageInSeconds = ((id >> 22) + 1420070400000) / 1000;
+            long ageInSeconds = (id >> 22) / 1000;
 
             return new DateTime(2015, 1, 1).AddSeconds(ageInSeconds);
         }

--- a/Oxide.Ext.Discord/Oxide.Ext.Discord.csproj
+++ b/Oxide.Ext.Discord/Oxide.Ext.Discord.csproj
@@ -2,7 +2,7 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <Version>1.0.3.0</Version>
+    <Version>1.0.4.0</Version>
     <AssemblyName>Oxide.Ext.Discord</AssemblyName>
     <Authors>PsychoTea</Authors>
     <Description>An Oxide extension for Discord.</Description>

--- a/Oxide.Ext.Discord/REST/Bucket.cs
+++ b/Oxide.Ext.Discord/REST/Bucket.cs
@@ -75,7 +75,7 @@
                 return;
             }
             
-            if (Reset >= Time.TimeSinceEpoch())
+            if (Remaining == 0 && Reset >= Time.TimeSinceEpoch())
             {
                 return;
             }

--- a/Oxide.Ext.Discord/REST/RESTHandler.cs
+++ b/Oxide.Ext.Discord/REST/RESTHandler.cs
@@ -16,10 +16,22 @@
         {
             this.apiKey = apiKey;
 
+            // Version
+            string version = "";
+            var exts = Oxide.Core.Interface.Oxide.GetAllExtensions();
+            foreach (var ext in exts)
+            {
+                if (ext.Name != "Discord") continue;
+                version = $"{ext.Version.Major}.{ext.Version.Minor}.{ext.Version.Patch}";
+                break;
+            }
+            //-
+
             headers = new Dictionary<string, string>()
             {
                 { "Authorization", $"Bot {this.apiKey}" },
-                { "Content-Type", "application/json" }
+                { "Content-Type", "application/json" },
+                { "User-Agent", $"DiscordBot (https://github.com/Trickyyy/Oxide.Ext.Discord, {version})" }
             };
         }
 

--- a/Oxide.Ext.Discord/REST/Request.cs
+++ b/Oxide.Ext.Discord/REST/Request.cs
@@ -39,6 +39,8 @@
 
         private Bucket bucket;
 
+        private byte retries = 0;
+
         public Request(RequestMethod method, string route, string endpoint, Dictionary<string, string> headers, object data, Action<RestResponse> callback)
         {
             this.Method = method;
@@ -86,11 +88,11 @@
 
                 if (httpResponse == null)
                 {
-                    Interface.Oxide.LogException($"[Discord Ext] A web request exception occured (internal error).", ex);
+                    Interface.Oxide.LogException($"[Discord Ext] A web request exception occured (internal error) [RETRY={retries}/3].", ex);
                     Interface.Oxide.LogError($"[Discord Ext] Request URL: [{Method.ToString()}] {RequestURL}");
                     // Interface.Oxide.LogError($"[Discord Ext] Exception message: {ex.Message}");
 
-                    this.Close();
+                    this.Close(++retries >= 3);
                     return;
                 }
 

--- a/Oxide.Ext.Discord/REST/Request.cs
+++ b/Oxide.Ext.Discord/REST/Request.cs
@@ -88,8 +88,8 @@
 
                 if (httpResponse == null)
                 {
-                    Interface.Oxide.LogException($"[Discord Ext] A web request exception occured (internal error) [RETRY={retries}/3].", ex);
-                    Interface.Oxide.LogError($"[Discord Ext] Request URL: [{Method.ToString()}] {RequestURL}");
+                    Interface.Oxide.LogException($"[Discord Extension] A web request exception occured (internal error) [RETRY={retries}/3].", ex);
+                    Interface.Oxide.LogError($"[Discord Extension] Request URL: [{Method.ToString()}] {RequestURL}");
                     // Interface.Oxide.LogError($"[Discord Ext] Exception message: {ex.Message}");
 
                     this.Close(++retries >= 3);
@@ -123,7 +123,7 @@
             }
             catch (Exception ex)
             {
-                Interface.Oxide.LogException("[Discord Ext] Request callback raised an exception", ex);
+                Interface.Oxide.LogException("[Discord Extension] Request callback raised an exception", ex);
             }
             finally
             {

--- a/Oxide.Ext.Discord/WebSockets/Socket.cs
+++ b/Oxide.Ext.Discord/WebSockets/Socket.cs
@@ -26,7 +26,7 @@
                 throw new NoURLException();
             }
 
-            if (socket != null && socket.ReadyState != WebSocketState.Closed)
+            if (socket != null && socket.ReadyState != WebSocketState.Closed && socket.ReadyState != WebSocketState.Closing)
             {
                 //throw new SocketRunningException(client);
                 // Assume force-reconenct
@@ -49,7 +49,7 @@
 
         public void Disconnect(bool normal = true)
         {
-            if (IsClosed()) return;
+            if (IsClosed() || IsClosing()) return;
 
             socket?.CloseAsync(normal ? CloseStatusCode.Normal : CloseStatusCode.Abnormal);
         }

--- a/Oxide.Ext.Discord/WebSockets/Socket.cs
+++ b/Oxide.Ext.Discord/WebSockets/Socket.cs
@@ -28,8 +28,11 @@
 
             if (socket != null && socket.ReadyState != WebSocketState.Closed)
             {
-                throw new SocketRunningException(client);
+                //throw new SocketRunningException(client);
+                // Assume force-reconenct
+                socket?.Close(CloseStatusCode.Abnormal);
             }
+            client.DestroyHeartbeat();
 
             socket = new WebSocket($"{url}/?v=6&encoding=json");
 
@@ -48,7 +51,7 @@
         {
             if (IsClosed()) return;
 
-            socket?.CloseAsync(normal ? CloseStatusCode.Normal : CloseStatusCode.NoStatus);
+            socket?.CloseAsync(normal ? CloseStatusCode.Normal : CloseStatusCode.Abnormal);
         }
 
         public void Send(string message, Action<bool> completed = null) => socket?.SendAsync(message, completed);

--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -290,14 +290,14 @@ namespace Oxide.Ext.Discord.WebSockets
                             GuildMember oldMember = client.DiscordServer.members.FirstOrDefault(x => x.user.id == memberUpdated.user.id);
                             if (oldMember != null)
                             {
-                                //client.DiscordServer.members.Remove(oldMember);
-                                if(memberUpdated.user != null)
-                                    oldMember.user = memberUpdated.user;
+                                int index = client.DiscordServer.members.IndexOf(oldMember);
+                                if (memberUpdated.user != null)
+                                    client.DiscordServer.members[index].user = memberUpdated.user;
                                 if (memberUpdated.nick != null)
-                                    oldMember.nick = memberUpdated.nick;
+                                    client.DiscordServer.members[index].nick = memberUpdated.nick;
                                 if (memberUpdated.roles != null)
-                                    oldMember.roles = memberUpdated.roles;
-                            }
+                                    client.DiscordServer.members[index].roles = memberUpdated.roles;
+                             }
 
                             client.CallHook("Discord_GuildMemberUpdate", null, memberUpdated, oldMember);
                             break;

--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -59,7 +59,7 @@ namespace Oxide.Ext.Discord.WebSockets
             if (e.Code == 4006)
             {
                 webSocket.hasConnectedOnce = false;
-                Interface.Oxide.LogWarning("[Discord Ext] Discord session no longer valid... Reconnecting...");
+                Interface.Oxide.LogWarning("[Discord Extension] Discord session no longer valid... Reconnecting...");
                 client.REST.Shutdown(); // Clean up buckets
                 webSocket.Connect(client.WSSURL);
                 client.CallHook("DiscordSocket_WebSocketClosed", null, e.Reason, e.Code, e.WasClean);
@@ -68,17 +68,17 @@ namespace Oxide.Ext.Discord.WebSockets
 
             if (!e.WasClean)
             {
-                Interface.Oxide.LogWarning($"[Discord Ext] Discord connection closed uncleanly: code {e.Code}, Reason: {e.Reason}");
+                Interface.Oxide.LogWarning($"[Discord Extension] Discord connection closed uncleanly: code {e.Code}, Reason: {e.Reason}");
 
                 if(retries >= 5)
                 {
-                    Interface.Oxide.LogError("[Discord Ext] Exceeded number of retries... Attempting in 15 seconds.");
+                    Interface.Oxide.LogError("[Discord Extension] Exceeded number of retries... Attempting in 15 seconds.");
                     Timer reconnecttimer = new Timer() { Interval = 15000f, AutoReset = false };
                     reconnecttimer.Elapsed += (object a, ElapsedEventArgs b) =>
                     {
                         if (client == null) return;
                         retries = 0;
-                        Interface.Oxide.LogWarning($"[Discord Ext] Attempting to reconnect to Discord...");
+                        Interface.Oxide.LogWarning($"[Discord Extension] Attempting to reconnect to Discord...");
                         client.REST.Shutdown(); // Clean up buckets
                         webSocket.Connect(client.WSSURL);
                     };
@@ -87,7 +87,7 @@ namespace Oxide.Ext.Discord.WebSockets
                 }
                 retries++;
 
-                Interface.Oxide.LogWarning($"[Discord Ext] Attempting to reconnect to Discord...");
+                Interface.Oxide.LogWarning($"[Discord Extension] Attempting to reconnect to Discord...");
                 client.REST.Shutdown(); // Clean up buckets
                 webSocket.Connect(client.WSSURL);
             }
@@ -102,9 +102,15 @@ namespace Oxide.Ext.Discord.WebSockets
 
         public void SocketErrored(object sender, ErrorEventArgs e)
         {
-            Interface.Oxide.LogWarning($"[Discord Ext] An error has occured: Response: {e.Message}");
+            Interface.Oxide.LogWarning($"[Discord Extension] An error has occured: Response: {e.Message}");
 
             client.CallHook("DiscordSocket_WebSocketErrored", null, e.Exception, e.Message);
+
+            if (client == null) return;
+            if (retries > 0) return; // Retry timer is already triggered
+            Interface.Oxide.LogWarning($"[Discord Extension] Attempting to reconnect to Discord...");
+            client.REST.Shutdown(); // Clean up buckets
+            webSocket.Connect(client.WSSURL);
         }
 
         public void SocketMessage(object sender, MessageEventArgs e)
@@ -161,6 +167,7 @@ namespace Oxide.Ext.Discord.WebSockets
                         case "RESUMED":
                         {
                             Resumed resumed = payload.EventData.ToObject<Resumed>();
+                            Interface.Oxide.LogWarning("[Discord Extension] Session resumed!");
                             client.CallHook("Discord_Resumed", null, resumed);
                             break;
                         }
@@ -508,7 +515,7 @@ namespace Oxide.Ext.Discord.WebSockets
                         default:
                         {
                             client.CallHook("Discord_UnhandledEvent", null, payload);
-                            Interface.Oxide.LogWarning($"[Discord Ext] [Debug] Unhandled event: {payload.EventName}");
+                            Interface.Oxide.LogWarning($"[Discord Extension] [Debug] Unhandled event: {payload.EventName}");
                             break;
                         }
                     }
@@ -544,7 +551,7 @@ namespace Oxide.Ext.Discord.WebSockets
                     reconnecttimer.Elapsed += (object a, ElapsedEventArgs b) =>
                     {
                         if (client == null) return;
-                        Interface.Oxide.LogWarning($"[Discord Ext] Attempting to reconnect to Discord...");
+                        Interface.Oxide.LogWarning($"[Discord Extension] Attempting to reconnect to Discord...");
                         client.REST.Shutdown(); // Clean up buckets
                         webSocket.Connect(client.WSSURL);
                     };
@@ -561,7 +568,7 @@ namespace Oxide.Ext.Discord.WebSockets
                     //client.Identify();
                     if (webSocket.hasConnectedOnce)
                     {
-                        Interface.Oxide.LogInfo("[DiscordExt] Attempting resume opcode...");
+                        Interface.Oxide.LogWarning("[Discord Extension] Attempting resume opcode...");
                         client.Resume();
                     }
                     else

--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -354,6 +354,9 @@ namespace Oxide.Ext.Discord.WebSockets
                         case "MESSAGE_CREATE":
                         {
                             Message messageCreate = payload.EventData.ToObject<Message>();
+                            Channel c = client.DiscordServer.channels.FirstOrDefault(x => x.id == messageCreate.channel_id);
+                            int cidx = client.DiscordServer.channels.IndexOf(c);
+                            client.DiscordServer.channels[cidx].last_message_id = messageCreate.id;
                             client.CallHook("Discord_MessageCreate", null, messageCreate);
                             break;
                         }

--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -49,6 +49,13 @@ namespace Oxide.Ext.Discord.WebSockets
                 Interface.Oxide.LogDebug($"Discord WebSocket closed. Code: {e.Code}, reason: {e.Reason}");
             }
 
+            if(client.requestReconnect)
+            {
+                client.requestReconnect = false;
+                webSocket.Connect(client.WSSURL);
+                return;
+            }
+
             if (e.Code == 4006)
             {
                 webSocket.hasConnectedOnce = false;
@@ -283,7 +290,13 @@ namespace Oxide.Ext.Discord.WebSockets
                             GuildMember oldMember = client.DiscordServer.members.FirstOrDefault(x => x.user.id == memberUpdated.user.id);
                             if (oldMember != null)
                             {
-                                client.DiscordServer.members.Remove(oldMember);
+                                //client.DiscordServer.members.Remove(oldMember);
+                                if(memberUpdated.user != null)
+                                    oldMember.user = memberUpdated.user;
+                                if (memberUpdated.nick != null)
+                                    oldMember.nick = memberUpdated.nick;
+                                if (memberUpdated.roles != null)
+                                    oldMember.roles = memberUpdated.roles;
                             }
 
                             client.CallHook("Discord_GuildMemberUpdate", null, memberUpdated, oldMember);


### PR DESCRIPTION
Discord Extension v1.0.4
- [Presence] nullable since & default status value "online"
- [Ratelimit] Missing remaining-header check re-added
- [Untested] Retries for a REST in case a random network timeout occured.
- Edits for PRESENCE_UPDATE, User and edits for reconnection attempts
- [Untested] Clean buckets used on reconnects (clean reconnections I hope?)
- [RESTHandler] Added missing User-Agent header
- Fixed GuildMemberUpdate removing GuildMember instead of updating it
- [Channel] Added missing elements + tracking last_message_id and updating it
- [Helpers/CreationTime] Timestamp from snowflake is added to Discord Epoch instead of Unix
- Multi guild support (check https://github.com/Trickyyy/Oxide.Ext.Discord/issues/5 )