### PR TITLE
Documentation fix

### DIFF
--- a/Hooks.md
+++ b/Hooks.md
@@ -80,7 +80,7 @@ void Discord_Resumed(Resumed resumed)
  
 ## Discord_ChannelCreate
 ```csharp
-void Discord_ChannelCreated(Channel channel)
+void Discord_ChannelCreate(Channel channel)
 {
     Puts("Discord Channel Created");
 }

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ void Discord_Resumed(Resumed resumed)
 ### Discord_ChannelCreate
 
 ```csharp
-void Discord_ChannelCreated(Channel channel)
+void Discord_ChannelCreate(Channel channel)
 {
     Puts("Discord Channel Created");
 }


### PR DESCRIPTION
As you can see in [SocketListener](https://github.com/Trickyyy/Oxide.Ext.Discord/blob/master/Oxide.Ext.Discord/WebSockets/SocketListner.cs#L206), there is mistake in hook name.

In documentation, hook **Discord_ChannelCreated** was renamed to **Discord_ChannelCreate**.