### PR TITLE
Add `parent_id` to the CreateGuildChannel method

### DIFF
--- a/Oxide.Ext.Discord/DiscordObjects/Guild.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Guild.cs
@@ -115,9 +115,9 @@
             client.REST.DoRequest($"/guilds/{id}/channels", RequestMethod.GET, null, callback);
         }
 
-        public void CreateGuildChannel(DiscordClient client, Channel channel, Action<Channel> callback = null) => CreateGuildChannel(client, channel.name, channel.type, channel.bitrate, channel.user_limit, channel.permission_overwrites, callback);
+        public void CreateGuildChannel(DiscordClient client, Channel channel, Action<Channel> callback = null) => CreateGuildChannel(client, channel.name, channel.type, channel.bitrate, channel.user_limit, channel.permission_overwrites, channel.parent_id, callback);
 
-        public void CreateGuildChannel(DiscordClient client, string name, ChannelType? type, int? bitrate, int? userLimit, List<Overwrite> permissionOverwrites, Action<Channel> callback = null)
+        public void CreateGuildChannel(DiscordClient client, string name, ChannelType? type, int? bitrate, int? userLimit, List<Overwrite> permissionOverwrites, string parent_id, Action<Channel> callback = null)
         {
             var jsonObj = new Dictionary<string, object>()
             {
@@ -125,7 +125,8 @@
                 { "type", type },
                 { "bitrate", bitrate },
                 { "user_limit", userLimit },
-                { "permission_overwrites", permissionOverwrites }
+                { "permission_overwrites", permissionOverwrites },
+								{ "parent_id", parent_id }
             };
 
             client.REST.DoRequest($"/guilds/{id}/channels", RequestMethod.POST, jsonObj, callback);

--- a/Oxide.Ext.Discord/DiscordObjects/Guild.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Guild.cs
@@ -126,7 +126,7 @@
                 { "bitrate", bitrate },
                 { "user_limit", userLimit },
                 { "permission_overwrites", permissionOverwrites },
-								{ "parent_id", parent_id }
+                { "parent_id", parent_id }
             };
 
             client.REST.DoRequest($"/guilds/{id}/channels", RequestMethod.POST, jsonObj, callback);


### PR DESCRIPTION
Hey,

As said in the title I've added `parent_id` to the payload in `CreateGuildChannel` so you can assign a parent category to the newly created channel