### PR TITLE
Add support for allowed_mentions Message field

### DIFF
--- a/Oxide.Ext.Discord/DiscordObjects/AllowedMentions.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/AllowedMentions.cs
@@ -1,0 +1,14 @@
+namespace Oxide.Ext.Discord.DiscordObjects
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class AllowedMentions
+    {
+        public List<string> parse { get; set; }
+
+        public List<string> roles { get; set; }
+
+        public List<string> users { get; set; }
+    }
+}

--- a/Oxide.Ext.Discord/DiscordObjects/Message.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Message.cs
@@ -5,7 +5,7 @@
     using System.Text;
     using Oxide.Ext.Discord.Helpers;
     using Oxide.Ext.Discord.REST;
-    
+
     public class Message
     {
         public string id { get; set; }
@@ -47,6 +47,8 @@
         public string webhook_id { get; set; }
 
         public MessageType? type { get; set; }
+
+        public AllowedMentions allowed_mentions { get; set; }
 
         public void Reply(DiscordClient client, Message message, bool ping = true, Action<Message> callback = null)
         {


### PR DESCRIPTION
See the [Allowed Mentions Object](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) docs on Discord for more information on this field. Essentially, it allows you to limit outgoing pings for `@everyone`, `@here`, role mentions, and user mentions.

This PR adds a `DiscordObjects.AllowedMentions` class, and adds it as the `allowed_mentions` field on `DiscordObjects.Message`. 

Note: this will only be relevant for outgoing messages, but it doesn't appear the library makes a distinction between incoming and outgoing messages.